### PR TITLE
Wait before drupal module releases

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,18 @@
     "platformAutomerge": true,
     "packageRules": [
         {
+            "matchPackagePatterns": ["^drupal/"],
+            "excludePackageNames": [
+                "drupal/core-dev-pinned",
+                "drupal/core-recommended",
+                "drupal/core-composer-scaffold",
+                "drupal/core-project-message",
+                "drupal/core-vendor-hardening"
+            ],
+            "minimumReleaseAge": 2,
+            "internalChecksFilter": "strict"
+        },
+        {
             "datasources": [
                 "packagist"
             ],


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

I'm trying this to reduce the spam for example we had with drupal/editor_advanced_link