### PR TITLE
Unstable version needs approval

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,12 @@
             ]
         },
         {
+            "description": "Unstable versions needs approval",
+            "matchManagers": ["composer"],
+            "matchCurrentVersion": "/.*(beta|alpha|rc).*/i",
+            "dependencyDashboardApproval": true
+        },
+        {
             "groupName": "twig packages",
             "groupSlug": "twig",
             "matchManagers": ["composer"],


### PR DESCRIPTION
#15

I haven't found a solution to make Renovate do the updates while not touching the version constraint.

So I activated "dependencyDashboardApproval" so that we can still see that there is an update to do.
