### PR TITLE
Revert TAC schedule and add note

### DIFF
--- a/_tarteaucitron.json
+++ b/_tarteaucitron.json
@@ -4,6 +4,8 @@
         {
             "matchManagers": ["npm"],
             "matchPackageNames": ["tarteaucitronjs"],
+            "schedule": ["before 8:00am every weekday"],
+            "prHeader": "This project uses tarteaucitron.io PRO and therefore must be always updated with the latest version."
         }
     ]
 }


### PR DESCRIPTION
Yesterday I was a bit rough (https://github.com/Akollade/renovate-config/commit/2bd78500dcd794b6e3a0925138d3bf5dfef35e34) and I deleted this "schedule" even though it was necessary.