### PR TITLE
New global schedule "once a month"

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,7 @@
         "github>akollade/renovate-config:_github-actions"
     ],
     "timezone": "Europe/Paris",
-    "schedule": ["on the 1st and 3rd day instance on Monday before 01:30pm"],
+    "schedule": ["on the 1st day instance on Monday before 05:00pm"],
     "updateNotScheduled": false,
     "rangeStrategy": "bump",
     "commitMessagePrefix": ":arrow_up:",


### PR DESCRIPTION
I think we can try this new schedule "once a month" : I have reworked the groups and automerge quite a bit, and the "vulnerabilityAlerts" system seems to work well.